### PR TITLE
Add Dash forecasting app

### DIFF
--- a/Users/abhinavdeshwar/Python/PP/2/README.md
+++ b/Users/abhinavdeshwar/Python/PP/2/README.md
@@ -1,0 +1,35 @@
+# Supply Chain Demand Forecasting App
+
+This Dash application provides interactive forecasting for supply-chain planning.
+
+## Setup
+
+1. **Create virtual environment**
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. **Run the app**
+
+```bash
+python app.py
+```
+
+3. **(VS Code)** Switch interpreter to the `venv` under workspace settings.
+
+## Manual Test Checklist
+
+- **Add Row should** append the entered data to the history table and update the chart.
+- **Clear All should** remove all rows from the history table and chart.
+- **Run Forecast should** compute forecasts and display the best model with metrics.
+
+## Screenshots
+
+*Add screenshots here*
+
+## Requirements
+
+See `requirements.txt` for exact package versions.

--- a/Users/abhinavdeshwar/Python/PP/2/app.py
+++ b/Users/abhinavdeshwar/Python/PP/2/app.py
@@ -1,0 +1,125 @@
+"""Main entry point for the Dash forecasting app."""
+
+from __future__ import annotations
+
+import dash
+from dash import Dash, html, dcc, dash_table
+import dash_bootstrap_components as dbc
+
+from callbacks import register_callbacks
+from models import FORECAST_FUNCS, PMDARIMA_AVAILABLE
+
+app = Dash(__name__, external_stylesheets=[dbc.themes.LUX], suppress_callback_exceptions=True)
+
+header = html.H2("Supply Chain Demand Forecasting", className="text-center my-4")
+
+card1 = dbc.Card(
+    [
+        dbc.CardHeader("1. Enter Historical Demand"),
+        dbc.CardBody(
+            dbc.Row([
+                dbc.Col([
+                    dbc.InputGroup([
+                        dbc.InputGroupText("Year"),
+                        dbc.Input(id="input-year", type="number", min=2000, step=1),
+                    ], className="mb-2"),
+                    dbc.InputGroup([
+                        dbc.InputGroupText("Month"),
+                        dbc.Input(id="input-month", type="number", min=1, max=12, step=1),
+                    ], className="mb-2"),
+                    dbc.InputGroup([
+                        dbc.InputGroupText("Demand"),
+                        dbc.Input(id="input-demand", type="number", min=0, step=1),
+                    ], className="mb-2"),
+                    dbc.Button("Add Row", id="add-row", className="btn-add me-2"),
+                    dbc.Button("Clear All", id="clear-rows", className="btn-clear"),
+                ], md=4),
+                dbc.Col([
+                    dash_table.DataTable(
+                        id="history-table",
+                        columns=[{"name": c, "id": c} for c in ["year", "month", "demand"]],
+                        data=[],
+                        row_deletable=True,
+                        style_table={"height": "300px", "overflowY": "auto"},
+                        style_cell={"textAlign": "center"},
+                        className="table table-sm table-striped",
+                    ),
+                    dcc.Graph(id="history-bar", style={"height": "200px"}),
+                ], md=8),
+            ])
+        ),
+        dcc.Store(id="row-store", data=[]),
+    ],
+    className="step-card card step-1",
+)
+
+models_options = [
+    {"label": name, "value": name} for name in FORECAST_FUNCS.keys()
+]
+card2 = dbc.Card(
+    [
+        dbc.CardHeader("2. Select Forecasting Models"),
+        dbc.CardBody(
+            dcc.Dropdown(
+                id="model-options",
+                options=models_options,
+                multi=True,
+                placeholder="Select models",
+                value=list(FORECAST_FUNCS.keys()) if False else [],
+                disabled=False,
+            )
+        ),
+    ],
+    className="step-card card step-2",
+)
+
+card3 = dbc.Card(
+    [
+        dbc.CardHeader("3. Configure Parameters"),
+        dbc.CardBody(
+            dbc.Row([
+                dbc.Col(dbc.InputGroup([
+                    dbc.InputGroupText("Horizon"),
+                    dbc.Input(id="input-horizon", type="number", min=1, value=3)
+                ]), md=4),
+                dbc.Col(dbc.InputGroup([
+                    dbc.InputGroupText("Lead Time"),
+                    dbc.Input(id="input-lead", type="number", min=0, value=1)
+                ]), md=4),
+                dbc.Col(dbc.InputGroup([
+                    dbc.InputGroupText("Safety Stock"),
+                    dbc.Input(id="input-safety", type="number", min=0, value=0)
+                ]), md=4),
+            ], className="mb-2"),
+            dbc.Button("Run Forecast", id="run-forecast", className="btn btn-primary")
+        ),
+    ],
+    className="step-card card step-3",
+)
+
+card4 = dbc.Card(
+    [
+        dbc.CardHeader("4. Results"),
+        dbc.CardBody(
+            [
+                dcc.Graph(id="results-graph"),
+                dash_table.DataTable(
+                    id="results-table",
+                    columns=[{"name": c, "id": c} for c in ["Model", "MAE", "MSE", "MAPE %", "Best"]],
+                    data=[],
+                    style_cell={"textAlign": "center"},
+                    className="table table-sm table-striped mb-2",
+                ),
+                html.Div(id="summary"),
+            ]
+        ),
+    ],
+    className="step-card card step-4",
+)
+
+app.layout = dbc.Container([header, card1, card2, card3, card4], fluid=True)
+
+register_callbacks(app)
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/Users/abhinavdeshwar/Python/PP/2/assets/custom.css
+++ b/Users/abhinavdeshwar/Python/PP/2/assets/custom.css
@@ -1,0 +1,59 @@
+/* Custom styling for supply-chain forecasting app */
+
+.card-header {
+    background: linear-gradient(135deg, #ff7f0e, #1f77b4);
+    color: #fff;
+    font-weight: 600;
+}
+
+.card.step-2 .card-header {
+    background: linear-gradient(135deg, #1f77b4, #17becf);
+}
+
+.card.step-3 .card-header {
+    background: linear-gradient(135deg, #2ca02c, #98df8a);
+}
+
+.card.step-4 .card-header {
+    background: linear-gradient(135deg, #d62728, #ff9896);
+}
+
+.btn-add {
+    background-color: #1f77b4;
+    color: #fff;
+}
+
+.btn-add:hover {
+    filter: brightness(90%);
+    color: #fff;
+}
+
+.btn-clear {
+    background-color: #d62728;
+    color: #fff;
+}
+
+.btn-clear:hover {
+    filter: brightness(90%);
+    color: #fff;
+}
+
+.table-sm {
+    font-size: 0.9rem;
+}
+
+.table-striped>tbody>tr:nth-of-type(odd) {
+    background-color: rgba(0,0,0,.05);
+}
+
+.dash-table-container .dash-spreadsheet-container th {
+    font-size: 0.9rem;
+}
+
+.dash-table-container .dash-spreadsheet-container td {
+    font-size: 0.9rem;
+}
+
+.step-card {
+    margin-bottom: 1rem;
+}

--- a/Users/abhinavdeshwar/Python/PP/2/callbacks.py
+++ b/Users/abhinavdeshwar/Python/PP/2/callbacks.py
@@ -1,0 +1,108 @@
+"""Dash callbacks for interactive forecasting."""
+
+from __future__ import annotations
+
+import dash
+from dash import Dash, Input, Output, State, dash_table, html, dcc
+import plotly.graph_objs as go
+import pandas as pd
+
+from models import FORECAST_FUNCS, mae, mse, mape
+from utils import parse_rows, validate_history, reorder_point
+
+
+# helper to create toast messages (not implemented; placeholder)
+def create_toast(message: str, color: str = "primary") -> html.Div:
+    return html.Div(message, className=f"alert alert-{color}")
+
+
+def register_callbacks(app: Dash) -> None:
+    @app.callback(
+        Output("history-table", "data"),
+        Output("history-bar", "figure"),
+        Output("row-store", "data"),
+        Input("add-row", "n_clicks"),
+        Input("clear-rows", "n_clicks"),
+        State("input-year", "value"),
+        State("input-month", "value"),
+        State("input-demand", "value"),
+        State("row-store", "data"),
+        prevent_initial_call=True,
+    )
+    def update_rows(add_clicks, clear_clicks, year, month, demand, data):
+        ctx = dash.callback_context
+        if not ctx.triggered:
+            raise dash.exceptions.PreventUpdate
+        action = ctx.triggered[0]["prop_id"].split(".")[0]
+        rows = data or []
+        if action == "add-row" and year and month and demand is not None:
+            rows.append({"year": int(year), "month": int(month), "demand": float(demand)})
+        elif action == "clear-rows":
+            rows = []
+        df = parse_rows(rows)
+        fig = go.Figure(data=[go.Bar(x=df["date"], y=df["demand"])]).update_layout(margin=dict(t=0, b=0))
+        return rows, fig, rows
+
+    @app.callback(
+        Output("model-options", "options"),
+        Output("model-options", "disabled"),
+        Input("model-options", "id"),
+        prevent_initial_call=False,
+    )
+    def toggle_arima(_):
+        options = [{"label": name, "value": name} for name in FORECAST_FUNCS.keys()]
+        disabled = False
+        return options, disabled
+
+    @app.callback(
+        Output("results-graph", "figure"),
+        Output("results-table", "data"),
+        Output("summary", "children"),
+        Input("run-forecast", "n_clicks"),
+        State("row-store", "data"),
+        State("model-options", "value"),
+        State("input-horizon", "value"),
+        State("input-lead", "value"),
+        State("input-safety", "value"),
+        prevent_initial_call=True,
+    )
+    def run_forecast(_, rows, selected_models, horizon, lead_time, safety_stock):
+        if not rows or not selected_models:
+            raise dash.exceptions.PreventUpdate
+        df = validate_history(parse_rows(rows))
+        series = pd.Series(df["demand"].values, index=df["date"])
+        horizon = int(horizon)
+        results = []
+        avg_demand = series.mean()
+        for name in selected_models:
+            fc, fit = FORECAST_FUNCS[name](series, horizon, return_fit=True)
+            fit_index = series.index[-len(fit):]
+            mae_v = mae(series.loc[fit_index], fit)
+            mse_v = mse(series.loc[fit_index], fit)
+            mape_v = mape(series.loc[fit_index], fit)
+            results.append({
+                "name": name,
+                "forecast": fc,
+                "mae": mae_v,
+                "mse": mse_v,
+                "mape": mape_v,
+                "fit": fit,
+            })
+        best = min(results, key=lambda r: r["mape"])
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=series.index, y=series, mode="lines+markers", name="Actual"))
+        for r in results:
+            line = dict(width=4 if r["name"] == best["name"] else 2)
+            fig.add_trace(go.Scatter(x=r["forecast"].index, y=r["forecast"], mode="lines", name=r["name"], line=line))
+        fig.update_layout(margin=dict(t=10, b=10))
+        table_data = [{
+            "Model": r["name"],
+            "MAE": f"{r['mae']:.2f}",
+            "MSE": f"{r['mse']:.2f}",
+            "MAPE %": f"{r['mape']:.2f}",
+            "Best": "Yes" if r["name"] == best["name"] else ""
+        } for r in results]
+        rop = reorder_point(best["forecast"].iloc[0], float(safety_stock), avg_demand, float(lead_time))
+        summary = dcc.Markdown(f"**Best model:** {best['name']}  \n**Reorder point:** {rop:.2f}")
+        return fig, table_data, summary
+

--- a/Users/abhinavdeshwar/Python/PP/2/mini_add_test.py
+++ b/Users/abhinavdeshwar/Python/PP/2/mini_add_test.py
@@ -1,0 +1,12 @@
+"""Simple smoke test for add-row logic."""
+
+
+from utils import parse_rows
+
+rows = []
+rows.append({"year": 2023, "month": 1, "demand": 10})
+rows.append({"year": 2023, "month": 2, "demand": 12})
+
+parsed = parse_rows(rows)
+print(parsed)
+

--- a/Users/abhinavdeshwar/Python/PP/2/models.py
+++ b/Users/abhinavdeshwar/Python/PP/2/models.py
@@ -1,0 +1,107 @@
+"""Forecasting models and metrics utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+import pandas as pd
+from pandas import Series
+from statsmodels.tsa.api import ExponentialSmoothing, SimpleExpSmoothing, Holt
+
+try:
+    from pmdarima import auto_arima  # type: ignore
+    PMDARIMA_AVAILABLE = True
+except Exception:  # pragma: no cover - pmdarima optional
+    PMDARIMA_AVAILABLE = False
+
+
+@dataclass
+class ForecastResult:
+    name: str
+    forecast: Series
+    mae: float
+    mse: float
+    mape: float
+    fit: Series | None = None
+
+
+def mae(y_true: Series, y_pred: Series) -> float:
+    return np.mean(np.abs(y_true - y_pred))
+
+
+def mse(y_true: Series, y_pred: Series) -> float:
+    return np.mean((y_true - y_pred) ** 2)
+
+
+def mape(y_true: Series, y_pred: Series) -> float:
+    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100
+
+
+def sma(series: Series, window: int, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    fit = series.rolling(window=window).mean()
+    last = fit.iloc[-1]
+    fc = pd.Series([last] * horizon, index=pd.date_range(series.index[-1] + pd.offsets.MonthBegin(), periods=horizon, freq="MS"))
+    return (fc, fit) if return_fit else (fc, None)
+
+
+def wma(series: Series, weights: list[int], horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    w = np.array(weights)
+    w = w / w.sum()
+    def calc(i):
+        if i < len(w):
+            return np.nan
+        window = series.iloc[i - len(w):i]
+        return np.sum(window.values * w)
+    fit = Series([calc(i) for i in range(len(series))], index=series.index)
+    last = fit.dropna().iloc[-1]
+    fc = pd.Series([last] * horizon, index=pd.date_range(series.index[-1] + pd.offsets.MonthBegin(), periods=horizon, freq="MS"))
+    return (fc, fit) if return_fit else (fc, None)
+
+
+def ses(series: Series, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    model = SimpleExpSmoothing(series).fit()
+    fc = model.forecast(horizon)
+    return (fc, model.fittedvalues) if return_fit else (fc, None)
+
+
+def des(series: Series, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    model = Holt(series).fit()
+    fc = model.forecast(horizon)
+    return (fc, model.fittedvalues) if return_fit else (fc, None)
+
+
+def trend_es(series: Series, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    model = ExponentialSmoothing(series, trend="add", seasonal=None).fit()
+    fc = model.forecast(horizon)
+    return (fc, model.fittedvalues) if return_fit else (fc, None)
+
+
+def holt_winters(series: Series, seasonal: str, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    model = ExponentialSmoothing(series, trend="add", seasonal=seasonal, seasonal_periods=12).fit()
+    fc = model.forecast(horizon)
+    return (fc, model.fittedvalues) if return_fit else (fc, None)
+
+
+def arima_model(series: Series, horizon: int, return_fit: bool = False) -> Tuple[Series, Series | None]:
+    if not PMDARIMA_AVAILABLE:
+        raise RuntimeError("pmdarima not available")
+    model = auto_arima(series, seasonal=True, m=12)
+    fc = pd.Series(model.predict(horizon), index=pd.date_range(series.index[-1] + pd.offsets.MonthBegin(), periods=horizon, freq="MS"))
+    fit = pd.Series(model.predict_in_sample(), index=series.index)
+    return (fc, fit) if return_fit else (fc, None)
+
+
+FORECAST_FUNCS: Dict[str, Callable[..., Tuple[Series, Series | None]]] = {
+    "SMA": lambda s, h, return_fit=False: sma(s, window=3, horizon=h, return_fit=return_fit),
+    "WMA": lambda s, h, return_fit=False: wma(s, weights=[1, 2, 3, 4, 5], horizon=h, return_fit=return_fit),
+    "SES": ses,
+    "DES": des,
+    "Trend ES": trend_es,
+    "HW Additive": lambda s, h, return_fit=False: holt_winters(s, "add", h, return_fit=return_fit),
+    "HW Multiplicative": lambda s, h, return_fit=False: holt_winters(s, "mul", h, return_fit=return_fit),
+}
+if PMDARIMA_AVAILABLE:
+    FORECAST_FUNCS["ARIMA"] = arima_model
+

--- a/Users/abhinavdeshwar/Python/PP/2/requirements.txt
+++ b/Users/abhinavdeshwar/Python/PP/2/requirements.txt
@@ -1,0 +1,7 @@
+dash>=2.11
+plotly>=5
+pandas
+numpy
+statsmodels
+pmdarima; sys_platform != 'darwin' or platform_machine != 'arm64'
+dash-bootstrap-components>=1.5

--- a/Users/abhinavdeshwar/Python/PP/2/utils.py
+++ b/Users/abhinavdeshwar/Python/PP/2/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for demand forecasting app."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def parse_rows(rows: list[dict]) -> pd.DataFrame:
+    """Convert list of row dicts with year, month, demand into DataFrame."""
+    if not rows:
+        return pd.DataFrame(columns=["date", "demand"])
+
+    df = pd.DataFrame(rows)
+    df["date"] = pd.to_datetime(df[["year", "month"]].assign(day=1))
+    df.sort_values("date", inplace=True)
+    df = df.drop(columns=[col for col in ["id"] if col in df])
+    df = df[["date", "demand"]]
+    df["demand"] = pd.to_numeric(df["demand"], errors="coerce")
+    df = df.dropna(subset=["demand"]).reset_index(drop=True)
+    return df
+
+
+def validate_history(df: pd.DataFrame) -> pd.DataFrame:
+    """Validate months count and interpolate missing interior months."""
+    if df.empty:
+        return df
+    months = len(df)
+    if not 1 <= months <= 60:
+        raise ValueError("History must contain between 1 and 60 months")
+    full_index = pd.date_range(df["date"].min(), df["date"].max(), freq="MS")
+    df = df.set_index("date").reindex(full_index)
+    df.index.name = "date"
+    df["demand"] = df["demand"].interpolate(method="linear")
+    return df.reset_index()
+
+
+def reorder_point(forecast_first: float, safety_stock: float, avg_demand: float, lead_time: float) -> float:
+    """Calculate reorder point."""
+    return forecast_first + safety_stock + avg_demand * lead_time


### PR DESCRIPTION
## Summary
- implement professional Dash supply chain forecasting app
- include forecasting models and utilities
- add callbacks for multi-step workflow
- provide custom CSS and smoke test
- documentation with setup instructions

## Testing
- `python3 -m py_compile Users/abhinavdeshwar/Python/PP/2/*.py`
- `python3 Users/abhinavdeshwar/Python/PP/2/mini_add_test.py` *(fails: No module named 'pandas')*
- `python3 Users/abhinavdeshwar/Python/PP/2/app.py` *(fails: No module named 'dash')*

------
https://chatgpt.com/codex/tasks/task_e_687f80fbc224832485a21464deb3a431